### PR TITLE
Consider g:jsonpath_delimeter in path searching

### DIFF
--- a/autoload/jsonpath.vim
+++ b/autoload/jsonpath.vim
@@ -41,7 +41,7 @@ function! jsonpath#scan_buffer(search_for, ...) "{{{
   " Parse arguments
   let search_for = a:search_for
   if type(search_for) == v:t_string
-    let search_for = split(search_for, '\.', 1)
+    let search_for = split(search_for, escape(g:jsonpath_delimeter, '.\'), 1)
   endif
   let is_searching = !empty(search_for)
 


### PR DESCRIPTION
I have a problem that I cannot search if attributes have dots. In other words:
```
:let g:jsonpath_delimeter='/'
:call jsonpath#goto('something.here/and.there')
Path not found: something.here/and.there
```


This PR will take into account `g:jsonpath_delimeter` when doing path search.